### PR TITLE
Removed the functionality to set and create a default download-cache directory

### DIFF
--- a/hexagonit/recipe/download/__init__.py
+++ b/hexagonit/recipe/download/__init__.py
@@ -21,9 +21,6 @@ class Recipe(object):
         self.options = options
         self.buildout = buildout
         self.name = name
-        buildout['buildout'].setdefault(
-            'download-cache',
-            os.path.join(buildout['buildout']['directory'], 'downloads'))
 
         options.setdefault('destination', os.path.join(
                 buildout['buildout']['parts-directory'],
@@ -72,9 +69,6 @@ class Recipe(object):
 
     def install(self):
         log = logging.getLogger(self.name)
-
-        if not os.path.exists(self.buildout['buildout']['download-cache']):
-            os.makedirs(self.buildout['buildout']['download-cache'])
 
         destination = self.options.get('destination')
         download = Download(self.buildout['buildout'], hash_name=self.options['hash-name'].strip() in TRUE_VALUES)


### PR DESCRIPTION
This fixes a bug that would cause some buildouts to fail if the download-cache directory does not exist. This occurs because this recipe altered the download-cache property of a buildout when it is initialized but only created the directory if it did not exist when the part is installed. Other parts that are installed before a part that uses this recipe would fail to download their packages since the download-cache directory does not exist. A simple solution is not to tinker with the download-cache directory at all since zc.buildout adequately handles it.
