### PR TITLE
Adding in on-update variable, for those who want to re-run on update

### DIFF
--- a/hexagonit/recipe/download/README.txt
+++ b/hexagonit/recipe/download/README.txt
@@ -610,3 +610,32 @@ section to demonstrate the dynamic naming.
 
     >>> ls(downloads)
     -  package-foobar-1.2.3.tgz
+
+
+Re-Running install on update
+============================
+Setting the ``on-update`` flag to ``true`` will re-run the install process on buildout update.
+
+    >>> write(sample_buildout, 'buildout.cfg',
+    ... """
+    ... [buildout]
+    ... newest = false
+    ... parts = package
+    ...
+    ... [package]
+    ... recipe = hexagonit.recipe.download
+    ... url = %(server)spackage1-1.2.3-final.tar.gz
+    ... md5sum = 821ecd681758d3fc03dcf76d3de00412
+    ... download-only = true
+    ... on-update = true
+    ... """ % dict(server=server, cache=cache))
+
+    >>> print(system(buildout))
+    Uninstalling package.
+    Installing package.
+    Downloading http://test.server/package1-1.2.3-final.tar.gz
+
+
+    >>> print(system(buildout))
+    Updating package.
+    Downloading http://test.server/package1-1.2.3-final.tar.gz

--- a/hexagonit/recipe/download/__init__.py
+++ b/hexagonit/recipe/download/__init__.py
@@ -35,6 +35,7 @@ class Recipe(object):
         options.setdefault('ignore-existing', 'false')
         options.setdefault('download-only', 'false')
         options.setdefault('hash-name', 'true')
+        options.setdefault('on-update', 'false')
         options['filename'] = options.get('filename', '').strip()
 
         # buildout -vv (or more) will trigger verbose mode
@@ -53,7 +54,8 @@ class Recipe(object):
         return dst
 
     def update(self):
-        pass
+        if self.options['on-update'].strip().lower() in TRUE_VALUES:
+            self.install()
 
     def calculate_base(self, extract_dir):
         """


### PR DESCRIPTION
Recently, I arrived at a problem where I needed to re-download a file every time I ran a buildout update (the file updates every single time, so I needed a non-cached fresh version). Seemed like the easier way to do this was follow the buildout convention of an on_update flag, which allows one to re-run directives on the update step if desired.

I'd be happy to make changes if you think there's a different way you would like this done. :)

Thanks!
