### PR TITLE
Add MANIFEST file.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include CHANGES.txt
+include CONTRIBUTORS.txt
+recursive-include hexagonit *


### PR DESCRIPTION
Currently, building the egg (python setup.py sdist in my case) won't work because geenrated .tar.gz will miss all the .txt (and all non-code) files.

This pull requests fixes this by adding a simple MANIFEST.in file.