### PR TITLE
-- allow multiple urls to be specified in url; split and try each one

### DIFF
--- a/hexagonit/recipe/download/__init__.py
+++ b/hexagonit/recipe/download/__init__.py
@@ -82,7 +82,17 @@ class Recipe(object):
 
         destination = self.options.get('destination')
         download = Download(self.buildout['buildout'], hash_name=self.options['hash-name'].strip() in TRUE_VALUES)
-        path, is_temp = download(self.options['url'], md5sum=self.options.get('md5sum'))
+        urls = self.options['url'].split()
+        excp = None
+        for url in urls:
+            try:
+                path, is_temp = download(url, md5sum=self.options.get('md5sum'))
+            except Exception as e:
+                excp = e
+                continue
+            break
+        else:
+            raise excp or Exception('error')
 
         parts = []
 


### PR DESCRIPTION
This patch allows multiple URLs to be specified in the single url.  It then splits and tries each one.  This is useful for when you want to list multiple mirrors (e.g., not mirroring all tarballs locally).  Used with relocatable-python.
