### PR TITLE
Be explicit about file encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from io import open
 from setuptools import setup, find_packages
 import os
 
@@ -6,7 +7,7 @@ name = 'hexagonit.recipe.download'
 
 
 def read(*rnames):
-    return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
+    return open(os.path.join(os.path.dirname(__file__), *rnames), encoding="utf-8").read()
 
 setup(
     name=name,


### PR DESCRIPTION
Avoids UnicodeDecodeError running at rc.local level where LANG is not set under Python 3, e.g. in a cloud-config.yml runcmd section.
